### PR TITLE
Save each Package (apk|abb) for later evaluation.

### DIFF
--- a/XAPerfTestRunner/BuildInfo.cs
+++ b/XAPerfTestRunner/BuildInfo.cs
@@ -8,11 +8,14 @@ namespace XAPerfTestRunner
 		public string ObjDir { get; }
 		public string BinDir { get; }
 
-		public BuildInfo (string targetFramework, string objDir, string binDir)
+		public string PackageFilename { get; }
+
+		public BuildInfo (string targetFramework, string objDir, string binDir, string packageFilename)
 		{
 			TargetFramework = FixPathSeparators (targetFramework);
 			ObjDir = FixPathSeparators (objDir);
 			BinDir = FixPathSeparators (binDir);
+			PackageFilename = FixPathSeparators (packageFilename);
 		}
 
 		string FixPathSeparators (string path)

--- a/XAPerfTestRunner/Constants.cs
+++ b/XAPerfTestRunner/Constants.cs
@@ -9,9 +9,11 @@ namespace XAPerfTestRunner
 		public const string DataRelativePath = "perfdata";
 		public const string CompareResultsRelativePath = ".";
 		public const string DefaultBuildCommand = "xabuild";
+
 		public const string LogFileName = "session.log";
 		public const string MSBuildLogDir = "build-logs";
 		public const string DeviceLogDir = "device-logs";
+		public const string ApkDir = "packages";
 		public const string ConfigFileName = ".xaptr.conf";
 		public const string RawResultsFileName = "raw-results.xml";
 		public const string DefaultLogTag = "default";

--- a/XAPerfTestRunner/MSBuildCommon.cs
+++ b/XAPerfTestRunner/MSBuildCommon.cs
@@ -16,6 +16,10 @@ namespace XAPerfTestRunner
 		const string OutputDir = "OutputDir";
 		const string OutputDirField = OutputDir + "=";
 
+		const string PackageFilename = "PackageFilename";
+
+		const string PackageFilenameField = PackageFilename + "=";
+
 		public List<string> StandardArguments { get; }
 		public string WorkingDirectory { get; set; } = String.Empty;
 
@@ -94,6 +98,7 @@ namespace XAPerfTestRunner
 			string? targetFramework = null;
 			string? objDir = null;
 			string? binDir = null;
+			string? packageFilename = null;
 
 			foreach (string field in info.Split (';', StringSplitOptions.RemoveEmptyEntries)) {
 				if (field.StartsWith (TargetFrameworkField, StringComparison.Ordinal)) {
@@ -110,13 +115,19 @@ namespace XAPerfTestRunner
 					binDir = field.Substring (OutputDirField.Length);
 					continue;
 				}
+
+				if (field.StartsWith (PackageFilenameField, StringComparison.Ordinal)) {
+					packageFilename = field.Substring (PackageFilenameField.Length);
+					continue;
+				}
 			}
 
 			ValidateField (targetFramework, TargetFramework);
 			ValidateField (objDir, ObjDir);
 			ValidateField (binDir, OutputDir);
+			ValidateField (packageFilename, PackageFilename);
 
-			return new BuildInfo (targetFramework!, objDir!, binDir!);
+			return new BuildInfo (targetFramework!, objDir!, binDir!, packageFilename!);
 
 			void ValidateField (string? fieldValue, string fieldName)
 			{

--- a/XAPerfTestRunner/Project.cs
+++ b/XAPerfTestRunner/Project.cs
@@ -459,6 +459,18 @@ namespace XAPerfTestRunner
 			);
 		}
 
+		string SavePackage (BuildInfo androidInfo, string outputPath)
+		{
+			var package = Path.Combine (FullProjectDirPath, androidInfo.BinDir, androidInfo.PackageFilename);
+			Log.MessageLine ($"Checking for {package}");
+			if (!File.Exists (package))
+				return null;
+			Log.MessageLine ($"Backing up {package} to {outputPath}");
+			Directory.CreateDirectory (Path.GetDirectoryName (outputPath!)!);
+			File.Copy (package, outputPath);
+			return Path.GetRelativePath(FullDataDirectoryPath, outputPath);
+		}
+
 		async Task<bool> RunPerformanceTest (RunDefinition run, AdbRunner adb)
 		{
 			Log.MessageLine (run.Description);
@@ -475,6 +487,9 @@ namespace XAPerfTestRunner
 			}
 
 			(string packageName, string activityName) = GetPackageAndMainActivityNames (androidInfo, run);
+
+			string apkPath = GetLogBasePath (Constants.ApkDir, "package", $"{run.LogTag}{Path.GetExtension (androidInfo.PackageFilename)}", projectGitCommit, projectGitBranch);
+			run.PackagePath = SavePackage (androidInfo, apkPath);
 
 			for (uint i = 0; i < repetitionCount; i++) {
 				uint runNum = i + 1;

--- a/XAPerfTestRunner/RunDefinition.cs
+++ b/XAPerfTestRunner/RunDefinition.cs
@@ -19,6 +19,8 @@ namespace XAPerfTestRunner
 		public List<RunResults> Results { get; } = new List<RunResults> ();
 		public string? BinlogPath { get; set; }
 
+		public string? PackagePath { get; set; }
+
 		public RunDefinition (Context context, ProjectConfigSingleRunDefinition runDefinition, ProjectConfig projectConfig)
 		{
 			LogTag = Utilities.FirstOf (runDefinition.LogTag, Constants.DefaultLogTag);
@@ -102,6 +104,10 @@ namespace XAPerfTestRunner
 			writer.WriteStartElement ("buildLog");
 			writer.WriteAttributeString ("path", BinlogPath ?? String.Empty);
 			writer.WriteEndElement (); // </buildLog>
+
+			writer.WriteStartElement ("package");
+			writer.WriteAttributeString ("path", PackagePath ?? String.Empty);
+			writer.WriteEndElement (); // </package>
 
 			writer.WriteStartElement ("results");
 			foreach (RunResults results in Results) {


### PR DESCRIPTION
As part of the performance gathering system we should also save
the package which was generated for later investigation, or for
use with `apkdiff`.

This PR relys on the following being added to the `BuildInfo` target

```
PackageFilename=$(_AndroidPackage)-Signed.$(AndroidPackageFormat);
```