### PR TITLE
Remove generic ParseNumber since we only ever parse uint

### DIFF
--- a/XAPerfTestRunner/Program.cs
+++ b/XAPerfTestRunner/Program.cs
@@ -23,7 +23,7 @@ namespace XAPerfTestRunner
 				{"p|perf", $"Run performance test (default: {parsedOptions.RunPerfTest})", v => parsedOptions.RunPerfTest = v == null ? false : true},
 				{"m|profile-managed", $"Profile managed portion of the app (default: {parsedOptions.RunManagedProfiler})", v => parsedOptions.RunManagedProfiler = v == null ? false : true},
 				{"n|profile-native", $"Profile native portion of the app (default: {parsedOptions.RunNativeProfiler})", v => parsedOptions.RunNativeProfiler = v == null ? false : true},
-				{"r|runs=", $"Number of runs for the performance test (default: {parsedOptions.RepetitionCount})", v => parsedOptions.RepetitionCount = ParseNumber (v, parsedOptions.RepetitionCount)},
+				{"r|runs=", $"Number of runs for the performance test (default: {parsedOptions.RepetitionCount})", v => parsedOptions.RepetitionCount = uint.Parse (v)},
 				{"f|fast-timing", $"Enable fast timing mode in Xamarin.Android, requires commit 1efa0cf46c9079fc06669a4434f597faf47504af, enabled by default", v => parsedOptions.UseFastTiming = v == null ? false : true},
 				{"no-fast-timing", $"Disable fast timing mode in Xamarin.Android", v => parsedOptions.UseFastTiming = false},
 				"",
@@ -172,17 +172,6 @@ namespace XAPerfTestRunner
 				return ret;
 
 			throw new InvalidOperationException ($"Unknown boolean value: {value}");
-		}
-
-		static T ParseNumber<T> (string value, T defaultValue = default(T)!)
-		{
-			switch (Type.GetTypeCode (typeof(T))) {
-				case TypeCode.UInt32:
-					return (T)((object)UInt32.Parse (value));
-
-				default:
-					throw new InvalidOperationException ($"Unsupported integer type {typeof(T)}");
-			}
 		}
 	}
 }


### PR DESCRIPTION
I build XAPerfTestRunner with NativeAOT and I found out that `ParseNumber<T>` did not work. 
It seems like at some point there was a need for a generic solution, but it doesn't seem to 
be needed anymore. I suggest simplifying the parsing and also making the `-r` argument 
codepath compatible with NativeAOT.

---

_EDIT:_ this was the runtime exception that NativeAOT was throwing:
```
Unhandled Exception: System.InvalidOperationException: Unsupported integer type System.Nullable`1[System.UInt32]
   at XAPerfTestRunner.Program.ParseNumber[T](String, T) + 0x398
   at XAPerfTestRunner.Program.<>c__DisplayClass0_0.<Main>b__4(String v) + 0x24
   at Mono.Options.Option.Invoke(OptionContext) + 0x20
   at Mono.Options.OptionSet.Parse(String, OptionContext) + 0x3c
   at Mono.Options.OptionSet.Parse(IEnumerable`1) + 0x1a0
   at XAPerfTestRunner.Program.<Main>d__0.MoveNext() + 0x7e8
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x24
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0x100
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task, ConfigureAwaitOptions) + 0x68
   at XAPerfTestRunner.Program.<Main>(String[] args) + 0x3c
   at xaptr!<BaseAddress>+0x501ae8
Abort trap: 6
```